### PR TITLE
Adding Rural/Urban Settlement and Population

### DIFF
--- a/analysis/02_new_model_input/06.0_ghs_rural_urban_pop.ipynb
+++ b/analysis/02_new_model_input/06.0_ghs_rural_urban_pop.ipynb
@@ -19,16 +19,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The jupyter_black extension is already loaded. To reload it, use:\n",
-      "  %reload_ext jupyter_black\n"
-     ]
+     "data": {
+      "text/html": [
+       "\n",
+       "                <script type=\"application/javascript\" id=\"jupyter_black\">\n",
+       "                (function() {\n",
+       "                    if (window.IPython === undefined) {\n",
+       "                        return\n",
+       "                    }\n",
+       "                    var msg = \"WARNING: it looks like you might have loaded \" +\n",
+       "                        \"jupyter_black in a non-lab notebook with \" +\n",
+       "                        \"`is_lab=True`. Please double check, and if \" +\n",
+       "                        \"loading with `%load_ext` please review the README!\"\n",
+       "                    console.log(msg)\n",
+       "                    alert(msg)\n",
+       "                })()\n",
+       "                </script>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -46,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -133,7 +151,7 @@
        "       [-200, -200, -200, ..., -200, -200, -200]], dtype=int16)"
       ]
      },
-     "execution_count": 106,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -148,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -157,7 +175,7 @@
        "CRS.from_wkt('PROJCS[\"World_Mollweide\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Mollweide\"],PARAMETER[\"central_meridian\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]')"
       ]
      },
-     "execution_count": 107,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -171,7 +189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -180,7 +198,7 @@
        "array([114.25,   4.55, 126.65,  21.15])"
       ]
      },
-     "execution_count": 108,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -191,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -200,7 +218,7 @@
        "False"
       ]
      },
-     "execution_count": 109,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -213,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -222,7 +240,7 @@
        "CRS.from_wkt('PROJCS[\"World_Mollweide\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Mollweide\"],PARAMETER[\"central_meridian\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]')"
       ]
      },
-     "execution_count": 110,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -234,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +278,7 @@
     "for grd in grid.Centroid:\n",
     "    grd_sel = grid[grid.Centroid == grd]\n",
     "    grid_rast = smod_raster_wgs84_clip.rio.clip(\n",
-    "        grd_sel[\"geometry\"], all_touched=True\n",
+    "        grd_sel[\"geometry\"], all_touched=False\n",
     "    )\n",
     "    smod_grid_vals.loc[grd_sel.index.values, [\"urban\"]] = (\n",
     "        (grid_rast >= 21) & (grid_rast <= 30)\n",
@@ -275,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -311,101 +329,101 @@
        "      <th>3716</th>\n",
        "      <td>20513</td>\n",
        "      <td>126.5E_7.3N</td>\n",
-       "      <td>0.008264</td>\n",
-       "      <td>0.991736</td>\n",
+       "      <td>0.01</td>\n",
+       "      <td>0.99</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3717</th>\n",
        "      <td>20514</td>\n",
        "      <td>126.5E_7.2N</td>\n",
-       "      <td>0.049587</td>\n",
-       "      <td>0.85124</td>\n",
-       "      <td>0.099174</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>0.82</td>\n",
+       "      <td>0.12</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3718</th>\n",
        "      <td>20515</td>\n",
        "      <td>126.5E_7.1N</td>\n",
-       "      <td>0.066116</td>\n",
-       "      <td>0.363636</td>\n",
-       "      <td>0.570248</td>\n",
+       "      <td>0.07</td>\n",
+       "      <td>0.26</td>\n",
+       "      <td>0.67</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3719</th>\n",
        "      <td>20516</td>\n",
        "      <td>126.5E_7.0N</td>\n",
-       "      <td>0.041322</td>\n",
-       "      <td>0.024793</td>\n",
-       "      <td>0.933884</td>\n",
+       "      <td>0.01</td>\n",
+       "      <td>0.01</td>\n",
+       "      <td>0.98</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3720</th>\n",
        "      <td>20676</td>\n",
        "      <td>126.6E_7.7N</td>\n",
-       "      <td>0.024793</td>\n",
-       "      <td>0.099174</td>\n",
-       "      <td>0.876033</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.04</td>\n",
+       "      <td>0.96</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3721</th>\n",
        "      <td>20677</td>\n",
        "      <td>126.6E_7.6N</td>\n",
-       "      <td>0.07438</td>\n",
-       "      <td>0.181818</td>\n",
-       "      <td>0.743802</td>\n",
+       "      <td>0.08</td>\n",
+       "      <td>0.08</td>\n",
+       "      <td>0.84</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3722</th>\n",
        "      <td>20678</td>\n",
        "      <td>126.6E_7.5N</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.479339</td>\n",
-       "      <td>0.520661</td>\n",
+       "      <td>0.42</td>\n",
+       "      <td>0.58</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3723</th>\n",
        "      <td>20679</td>\n",
        "      <td>126.6E_7.4N</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.190083</td>\n",
-       "      <td>0.809917</td>\n",
+       "      <td>0.109091</td>\n",
+       "      <td>0.890909</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3724</th>\n",
        "      <td>20680</td>\n",
        "      <td>126.6E_7.3N</td>\n",
-       "      <td>0.033058</td>\n",
-       "      <td>0.297521</td>\n",
-       "      <td>0.669421</td>\n",
+       "      <td>0.03</td>\n",
+       "      <td>0.25</td>\n",
+       "      <td>0.72</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3725</th>\n",
        "      <td>20681</td>\n",
        "      <td>126.6E_7.2N</td>\n",
-       "      <td>0.024793</td>\n",
-       "      <td>0.099174</td>\n",
-       "      <td>0.876033</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.07</td>\n",
+       "      <td>0.93</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "         id     Centroid     urban     rural     water\n",
-       "3716  20513  126.5E_7.3N  0.008264  0.991736       0.0\n",
-       "3717  20514  126.5E_7.2N  0.049587   0.85124  0.099174\n",
-       "3718  20515  126.5E_7.1N  0.066116  0.363636  0.570248\n",
-       "3719  20516  126.5E_7.0N  0.041322  0.024793  0.933884\n",
-       "3720  20676  126.6E_7.7N  0.024793  0.099174  0.876033\n",
-       "3721  20677  126.6E_7.6N   0.07438  0.181818  0.743802\n",
-       "3722  20678  126.6E_7.5N       0.0  0.479339  0.520661\n",
-       "3723  20679  126.6E_7.4N       0.0  0.190083  0.809917\n",
-       "3724  20680  126.6E_7.3N  0.033058  0.297521  0.669421\n",
-       "3725  20681  126.6E_7.2N  0.024793  0.099174  0.876033"
+       "         id     Centroid urban     rural     water\n",
+       "3716  20513  126.5E_7.3N  0.01      0.99       0.0\n",
+       "3717  20514  126.5E_7.2N  0.06      0.82      0.12\n",
+       "3718  20515  126.5E_7.1N  0.07      0.26      0.67\n",
+       "3719  20516  126.5E_7.0N  0.01      0.01      0.98\n",
+       "3720  20676  126.6E_7.7N   0.0      0.04      0.96\n",
+       "3721  20677  126.6E_7.6N  0.08      0.08      0.84\n",
+       "3722  20678  126.6E_7.5N   0.0      0.42      0.58\n",
+       "3723  20679  126.6E_7.4N   0.0  0.109091  0.890909\n",
+       "3724  20680  126.6E_7.3N  0.03      0.25      0.72\n",
+       "3725  20681  126.6E_7.2N   0.0      0.07      0.93"
       ]
      },
-     "execution_count": 113,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -416,7 +434,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count    3.726000e+03\n",
+       "mean     1.000000e+00\n",
+       "std      1.311743e-17\n",
+       "min      1.000000e+00\n",
+       "25%      1.000000e+00\n",
+       "50%      1.000000e+00\n",
+       "75%      1.000000e+00\n",
+       "max      1.000000e+00\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "smod_grid_vals[[\"urban\", \"rural\", \"water\"]].sum(axis=1).describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +486,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -489,12 +535,16 @@
     "        - re-projecting the grid seems the way to go.\n",
     "- Merging raster layers into one takes a lot of storage. \n",
     "    - It also results in higher values.\n",
-    "- A re-projected raster layer takes even more space and is better to just re-project on the fly."
+    "- A re-projected raster layer takes even more space and is better to just re-project on the fly.\n",
+    "\n",
+    "SOLUTION: Re-project grid to raster CRS\n",
+    "The sum of values as total population in grid.\n",
+    "Each raster is computed separately."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -506,7 +556,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -522,7 +572,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -536,10 +586,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# looping over tif files\n",
     "for file in tif_list:\n",
     "    pop_raster = rasterio.open(input_dir / \"POP\" / file)\n",
     "    pop_array = pop_raster.read(1)\n",
@@ -548,7 +599,7 @@
     "        pop_array,\n",
     "        stats=[\"sum\"],\n",
     "        nodata=-200,\n",
-    "        all_touched=True,\n",
+    "        all_touched=False,\n",
     "        affine=pop_raster.transform,\n",
     "    )\n",
     "    grid_stats = pd.DataFrame(pop_stats)\n",
@@ -586,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -596,7 +647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -672,24 +723,24 @@
        "      <th>3</th>\n",
        "      <td>4640</td>\n",
        "      <td>117.0E_8.1N</td>\n",
-       "      <td>5118.586441</td>\n",
+       "      <td>4970.477311</td>\n",
        "      <td>NaN</td>\n",
        "      <td>None</td>\n",
-       "      <td>3991.248616</td>\n",
+       "      <td>3910.025018</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>1127.337824</td>\n",
+       "      <td>1060.452293</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>4641</td>\n",
        "      <td>117.0E_8.0N</td>\n",
-       "      <td>12421.360279</td>\n",
+       "      <td>12408.594656</td>\n",
        "      <td>NaN</td>\n",
        "      <td>None</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>12421.360279</td>\n",
+       "      <td>12408.594656</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -708,61 +759,61 @@
        "      <th>3721</th>\n",
        "      <td>20677</td>\n",
        "      <td>126.6E_7.6N</td>\n",
-       "      <td>17758.051774</td>\n",
+       "      <td>17619.701390</td>\n",
        "      <td>NaN</td>\n",
        "      <td>None</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>17758.051774</td>\n",
+       "      <td>17619.701390</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3722</th>\n",
        "      <td>20678</td>\n",
        "      <td>126.6E_7.5N</td>\n",
-       "      <td>6383.934604</td>\n",
+       "      <td>5623.069564</td>\n",
        "      <td>NaN</td>\n",
        "      <td>None</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>6383.934604</td>\n",
+       "      <td>5623.069564</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3723</th>\n",
        "      <td>20679</td>\n",
        "      <td>126.6E_7.4N</td>\n",
-       "      <td>6933.484614</td>\n",
+       "      <td>5912.671746</td>\n",
        "      <td>NaN</td>\n",
        "      <td>None</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>6933.484614</td>\n",
+       "      <td>5912.671746</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3724</th>\n",
        "      <td>20680</td>\n",
        "      <td>126.6E_7.3N</td>\n",
-       "      <td>11363.645484</td>\n",
+       "      <td>11254.164413</td>\n",
        "      <td>NaN</td>\n",
        "      <td>None</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>11363.645484</td>\n",
+       "      <td>11254.164413</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3725</th>\n",
        "      <td>20681</td>\n",
        "      <td>126.6E_7.2N</td>\n",
-       "      <td>3225.272844</td>\n",
+       "      <td>3188.718115</td>\n",
        "      <td>NaN</td>\n",
        "      <td>None</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>3225.272844</td>\n",
+       "      <td>3188.718115</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -774,32 +825,32 @@
        "0       101  114.3E_11.1N      0.000000     NaN   None          NaN     NaN   \n",
        "1      4475   116.9E_7.9N      0.000000     NaN   None          NaN     NaN   \n",
        "2      4639   117.0E_8.2N    197.339034     NaN   None   197.339034     NaN   \n",
-       "3      4640   117.0E_8.1N   5118.586441     NaN   None  3991.248616     NaN   \n",
-       "4      4641   117.0E_8.0N  12421.360279     NaN   None          NaN     NaN   \n",
+       "3      4640   117.0E_8.1N   4970.477311     NaN   None  3910.025018     NaN   \n",
+       "4      4641   117.0E_8.0N  12408.594656     NaN   None          NaN     NaN   \n",
        "...     ...           ...           ...     ...    ...          ...     ...   \n",
-       "3721  20677   126.6E_7.6N  17758.051774     NaN   None          NaN     NaN   \n",
-       "3722  20678   126.6E_7.5N   6383.934604     NaN   None          NaN     NaN   \n",
-       "3723  20679   126.6E_7.4N   6933.484614     NaN   None          NaN     NaN   \n",
-       "3724  20680   126.6E_7.3N  11363.645484     NaN   None          NaN     NaN   \n",
-       "3725  20681   126.6E_7.2N   3225.272844     NaN   None          NaN     NaN   \n",
+       "3721  20677   126.6E_7.6N  17619.701390     NaN   None          NaN     NaN   \n",
+       "3722  20678   126.6E_7.5N   5623.069564     NaN   None          NaN     NaN   \n",
+       "3723  20679   126.6E_7.4N   5912.671746     NaN   None          NaN     NaN   \n",
+       "3724  20680   126.6E_7.3N  11254.164413     NaN   None          NaN     NaN   \n",
+       "3725  20681   126.6E_7.2N   3188.718115     NaN   None          NaN     NaN   \n",
        "\n",
        "            R9_C30        R9_C31  \n",
        "0              NaN           NaN  \n",
        "1         0.000000           NaN  \n",
        "2              NaN           NaN  \n",
-       "3      1127.337824           NaN  \n",
-       "4     12421.360279           NaN  \n",
+       "3      1060.452293           NaN  \n",
+       "4     12408.594656           NaN  \n",
        "...            ...           ...  \n",
-       "3721           NaN  17758.051774  \n",
-       "3722           NaN   6383.934604  \n",
-       "3723           NaN   6933.484614  \n",
-       "3724           NaN  11363.645484  \n",
-       "3725           NaN   3225.272844  \n",
+       "3721           NaN  17619.701390  \n",
+       "3722           NaN   5623.069564  \n",
+       "3723           NaN   5912.671746  \n",
+       "3724           NaN  11254.164413  \n",
+       "3725           NaN   3188.718115  \n",
        "\n",
        "[3726 rows x 9 columns]"
       ]
      },
-     "execution_count": 123,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -810,16 +861,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "119328366.48788711"
+       "116832667.26530215"
       ]
      },
-     "execution_count": 124,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -830,7 +881,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -842,7 +893,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -889,8 +940,8 @@
        "      <td>4475</td>\n",
        "      <td>116.9E_7.9N</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.024793</td>\n",
-       "      <td>0.975207</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -898,8 +949,8 @@
        "      <td>4639</td>\n",
        "      <td>117.0E_8.2N</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.008264</td>\n",
-       "      <td>0.991736</td>\n",
+       "      <td>0.01</td>\n",
+       "      <td>0.99</td>\n",
        "      <td>197.339034</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -907,18 +958,18 @@
        "      <td>4640</td>\n",
        "      <td>117.0E_8.1N</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.338843</td>\n",
-       "      <td>0.661157</td>\n",
-       "      <td>5118.586441</td>\n",
+       "      <td>0.31</td>\n",
+       "      <td>0.69</td>\n",
+       "      <td>4970.477311</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>4641</td>\n",
        "      <td>117.0E_8.0N</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.793388</td>\n",
-       "      <td>0.206612</td>\n",
-       "      <td>12421.360279</td>\n",
+       "      <td>0.77</td>\n",
+       "      <td>0.23</td>\n",
+       "      <td>12408.594656</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
@@ -933,46 +984,46 @@
        "      <th>3721</th>\n",
        "      <td>20677</td>\n",
        "      <td>126.6E_7.6N</td>\n",
-       "      <td>0.07438</td>\n",
-       "      <td>0.181818</td>\n",
-       "      <td>0.743802</td>\n",
-       "      <td>17758.051774</td>\n",
+       "      <td>0.08</td>\n",
+       "      <td>0.08</td>\n",
+       "      <td>0.84</td>\n",
+       "      <td>17619.701390</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3722</th>\n",
        "      <td>20678</td>\n",
        "      <td>126.6E_7.5N</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.479339</td>\n",
-       "      <td>0.520661</td>\n",
-       "      <td>6383.934604</td>\n",
+       "      <td>0.42</td>\n",
+       "      <td>0.58</td>\n",
+       "      <td>5623.069564</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3723</th>\n",
        "      <td>20679</td>\n",
        "      <td>126.6E_7.4N</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.190083</td>\n",
-       "      <td>0.809917</td>\n",
-       "      <td>6933.484614</td>\n",
+       "      <td>0.109091</td>\n",
+       "      <td>0.890909</td>\n",
+       "      <td>5912.671746</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3724</th>\n",
        "      <td>20680</td>\n",
        "      <td>126.6E_7.3N</td>\n",
-       "      <td>0.033058</td>\n",
-       "      <td>0.297521</td>\n",
-       "      <td>0.669421</td>\n",
-       "      <td>11363.645484</td>\n",
+       "      <td>0.03</td>\n",
+       "      <td>0.25</td>\n",
+       "      <td>0.72</td>\n",
+       "      <td>11254.164413</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3725</th>\n",
        "      <td>20681</td>\n",
        "      <td>126.6E_7.2N</td>\n",
-       "      <td>0.024793</td>\n",
-       "      <td>0.099174</td>\n",
-       "      <td>0.876033</td>\n",
-       "      <td>3225.272844</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.07</td>\n",
+       "      <td>0.93</td>\n",
+       "      <td>3188.718115</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -980,23 +1031,23 @@
        "</div>"
       ],
       "text/plain": [
-       "         id      Centroid     urban     rural     water     total_pop\n",
-       "0       101  114.3E_11.1N       0.0       0.0       1.0      0.000000\n",
-       "1      4475   116.9E_7.9N       0.0  0.024793  0.975207      0.000000\n",
-       "2      4639   117.0E_8.2N       0.0  0.008264  0.991736    197.339034\n",
-       "3      4640   117.0E_8.1N       0.0  0.338843  0.661157   5118.586441\n",
-       "4      4641   117.0E_8.0N       0.0  0.793388  0.206612  12421.360279\n",
-       "...     ...           ...       ...       ...       ...           ...\n",
-       "3721  20677   126.6E_7.6N   0.07438  0.181818  0.743802  17758.051774\n",
-       "3722  20678   126.6E_7.5N       0.0  0.479339  0.520661   6383.934604\n",
-       "3723  20679   126.6E_7.4N       0.0  0.190083  0.809917   6933.484614\n",
-       "3724  20680   126.6E_7.3N  0.033058  0.297521  0.669421  11363.645484\n",
-       "3725  20681   126.6E_7.2N  0.024793  0.099174  0.876033   3225.272844\n",
+       "         id      Centroid urban     rural     water     total_pop\n",
+       "0       101  114.3E_11.1N   0.0       0.0       1.0      0.000000\n",
+       "1      4475   116.9E_7.9N   0.0       0.0       1.0      0.000000\n",
+       "2      4639   117.0E_8.2N   0.0      0.01      0.99    197.339034\n",
+       "3      4640   117.0E_8.1N   0.0      0.31      0.69   4970.477311\n",
+       "4      4641   117.0E_8.0N   0.0      0.77      0.23  12408.594656\n",
+       "...     ...           ...   ...       ...       ...           ...\n",
+       "3721  20677   126.6E_7.6N  0.08      0.08      0.84  17619.701390\n",
+       "3722  20678   126.6E_7.5N   0.0      0.42      0.58   5623.069564\n",
+       "3723  20679   126.6E_7.4N   0.0  0.109091  0.890909   5912.671746\n",
+       "3724  20680   126.6E_7.3N  0.03      0.25      0.72  11254.164413\n",
+       "3725  20681   126.6E_7.2N   0.0      0.07      0.93   3188.718115\n",
        "\n",
        "[3726 rows x 6 columns]"
       ]
      },
-     "execution_count": 126,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1007,7 +1058,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/analysis/02_new_model_input/06.0_ghs_rural_urban_pop.md
+++ b/analysis/02_new_model_input/06.0_ghs_rural_urban_pop.md
@@ -109,7 +109,7 @@ smod_grid_vals = pd.DataFrame(
 for grd in grid.Centroid:
     grd_sel = grid[grid.Centroid == grd]
     grid_rast = smod_raster_wgs84_clip.rio.clip(
-        grd_sel["geometry"], all_touched=True
+        grd_sel["geometry"], all_touched=False
     )
     smod_grid_vals.loc[grd_sel.index.values, ["urban"]] = (
         (grid_rast >= 21) & (grid_rast <= 30)
@@ -179,6 +179,10 @@ NOTE:
 - A re-projected raster layer takes even more space
 and is better to just re-project on the fly.
 
+SOLUTION: Re-project grid to raster CRS
+The sum of values as total population in grid.
+Each raster is computed separately.
+
 ```python
 # merging rasters using gdal
 #! gdalbuildvrt
@@ -211,6 +215,7 @@ grid_crs = grid.to_crs(pop_raster.crs.to_dict())
 ```
 
 ```python
+# looping over tif files
 for file in tif_list:
     pop_raster = rasterio.open(input_dir / "POP" / file)
     pop_array = pop_raster.read(1)
@@ -219,7 +224,7 @@ for file in tif_list:
         pop_array,
         stats=["sum"],
         nodata=-200,
-        all_touched=True,
+        all_touched=False,
         affine=pop_raster.transform,
     )
     grid_stats = pd.DataFrame(pop_stats)


### PR DESCRIPTION
This notebook describes the process of downloading and aggregating GHS data
from [here](https://ghsl.jrc.ec.europa.eu/download.php?).
The notebook contains aggregation for the grid:

- Classification of pixels as rural or urban for the raster.

- Using 21 and above for urban and 13 and below for rural.

- Fraction of each grid pixel that is rural/ urban/ water

- Find population by grid pixel.

The epoch used is closest to the date `27th Feb 2023` and would be 2025.